### PR TITLE
fix threshold misspellings in content and guc

### DIFF
--- a/admin/ClusterExpansion.html.md.erb
+++ b/admin/ClusterExpansion.html.md.erb
@@ -179,10 +179,10 @@ For example purposes in this procedure, we are adding a new node named `sdw4`.
 14. To maintain optimal cluster performance, rebalance HDFS data by running the following command:
 15. 
     ```shell
-    $ sudo -u hdfs hdfs balancer -threshold threshhold_value
+    $ sudo -u hdfs hdfs balancer -threshold threshold_value
     ```
     
-    where *threshhold\_value* represents how much a DataNode's disk usage, in percentage, can differ from overall disk usage in the cluster. Adjust the threshold value according to the needs of your production data and disk. The smaller the value, the longer the rebalance time.
+    where *threshold\_value* represents how much a DataNode's disk usage, in percentage, can differ from overall disk usage in the cluster. Adjust the threshold value according to the needs of your production data and disk. The smaller the value, the longer the rebalance time.
 >
     **Note:** If you do not specify a threshold, then a default value of 20 is used. If the balancer detects that a DataNode is using less than a 20% difference of the cluster's overall disk usage, then data on that node will not be rebalanced. For example, if disk usage across all DataNodes in the cluster is 40% of the cluster's total disk-storage capacity, then the balancer script ensures that a DataNode's disk usage is between 20% and 60% of that DataNode's disk-storage capacity. DataNodes whose disk usage falls within that percentage range will not be rebalanced.
 

--- a/admin/ambari-admin.html.md.erb
+++ b/admin/ambari-admin.html.md.erb
@@ -408,7 +408,7 @@ This alert is triggered when any of the HAWQ Segments fail to register with the 
 
 * Percent HAWQ Segment Status Available:
 This Alert monitors the percentage of HAWQ segments available versus total segments. 
-   Alerts for **WARN**, and **CRITICAL** are displayed when the number of unresponsive HAWQ segments in the cluster is greater than the specified threshhold. Otherwise, the status will show as **OK**.
+   Alerts for **WARN**, and **CRITICAL** are displayed when the number of unresponsive HAWQ segments in the cluster is greater than the specified threshold. Otherwise, the status will show as **OK**.
 
 * PXF Process Alerts:
 PXF Process alerts are triggered when a PXF process on a node is down or not responding on the network. If PXF Alerts are enabled, the Alert status is shown on the PXF Status page.
@@ -423,10 +423,10 @@ To customize the interval, perform the following steps:
 3.  Enter a number for how often to check status for the selected Alert, then click **Save**. The interval must be specified in whole minutes.
 
 
-#### Setting the Available HAWQ Segment Threshhold
+#### Setting the Available HAWQ Segment Threshold
 HAWQ monitors the percentage of available HAWQ segments and can send an alert when a specified percent of unresponsive segments is reached. 
 
-To set the threshhold for the unresponsive segments that will trigger an alert:
+To set the threshold for the unresponsive segments that will trigger an alert:
 
    1.  Click on **Percent HAWQ Segments Available**. 
    2.  Click **Edit**. Enter the percentage of total segments to create a **Warning** alert (default is 10 percent of the total segments) or **Critical** alert (default is 25 percent of total segments).

--- a/reference/guc/parameter_definitions.html.md.erb
+++ b/reference/guc/parameter_definitions.html.md.erb
@@ -110,7 +110,7 @@ Descriptions of the HAWQ server configuration parameters listed alphabetically.
 
 -   **[gp\_autostats\_mode](../../reference/guc/parameter_definitions.html#gp_autostats_mode)**
 
--   **[gp\_autostats\_on\_change\_threshhold](../../reference/guc/parameter_definitions.html#topic_imj_zhf_gw)**
+-   **[gp\_autostats\_on\_change\_threshold](../../reference/guc/parameter_definitions.html#topic_imj_zhf_gw)**
 
 -   **[gp\_backup\_directIO](../../reference/guc/parameter_definitions.html#gp_backup_directIO)**
 
@@ -1111,7 +1111,7 @@ Automatic statistics collection is triggered if data is inserted directly in a l
 </tbody>
 </table>
 
-## <a name="topic_imj_zhf_gw"></a>gp\_autostats\_on\_change\_threshhold
+## <a name="topic_imj_zhf_gw"></a>gp\_autostats\_on\_change\_threshold
 
 Specifies the threshold for automatic statistics collection when `gp_autostats_mode` is set to `on_change`. When a triggering table operation affects a number of rows exceeding this threshold, `ANALYZE         `is added and statistics are collected for the table.
 


### PR DESCRIPTION
fixed a few misspellings of the word threshold in both doc content and gp_autostats_on_change_threshold guc.