### PR TITLE
Feature/hawqcheck hadoopopt

### DIFF
--- a/reference/cli/admin_utilities/hawqcheck.html.md.erb
+++ b/reference/cli/admin_utilities/hawqcheck.html.md.erb
@@ -25,9 +25,9 @@ hawq check -?
 
 ## <a id="topic1__section3"></a>Description
 
-The `hawq check` utility determines the platform on which you are running HAWQ and validates various platform-specific configuration settings as well as HAWQ and HDFS-specific configuration settings. In order to perform HAWQ configuration checks, make sure HAWQ has been already started and `hawq config` works. For HDFS checks, you should either set the HADOOP\_HOME environment variable or give the hadoop installation location using `--hadoop` option.
+The `hawq check` utility determines the platform on which you are running HAWQ and validates various platform-specific configuration settings as well as HAWQ and HDFS-specific configuration settings. In order to perform HAWQ configuration checks, make sure HAWQ has been already started and `hawq config` works. For HDFS checks, you should either set the HADOOP\_HOME environment variable or provide the hadoop installation location using `--hadoop` option.
 
-The `hawq check` utility can use a host file or a file previously created with the `--zipout `option to validate platform settings. If `GPCHECK_ERROR` displays, one or more validation checks failed. You can also use `hawq check` to gather and view platform settings on hosts without running validation checks. When running checks, `hawq check` compares your actual configuration setting with an expected value listed in a config file (`$GPHOME/etc/hawq check.cnf` by default). You must modify your configuration values for "mount.points" and "diskusage.monitor.mounts" to reflect the actual mount points you want to check, as a comma-separated list. Otherwise, the utility only checks the root directory, which may not be helpful.
+The `hawq check` utility can use a host file or a file previously created with the `--zipout `option to validate platform settings. If `GPCHECK_ERROR` displays, one or more validation checks failed. You can also use `hawq check` to gather and view platform settings on hosts without running validation checks. When running checks, `hawq check` compares your actual configuration setting with an expected value listed in a config file (`$GPHOME/etc/hawq_check.cnf` by default). You must modify your configuration values for "mount.points" and "diskusage.monitor.mounts" to reflect the actual mount points you want to check, as a comma-separated list. Otherwise, the utility only checks the root directory, which may not be helpful.
 
 An example is shown below:
 
@@ -54,7 +54,7 @@ diskusage.monitor.mounts = /,/data1,/data2
 <dd>The name of a configuration file to use instead of the default file `$GPHOME/etc/hawq_check.cnf`.</dd>
 
 <dt>-\\\-hadoop, -\\\-hadoop-home \<hadoop\_home\>  </dt>
-<dd>Use this option to specify your hadoop installation location so that `hawq check` can validate HDFS settings. This option is not needed if `HADOOP_HOME` environment variable is set.</dd>
+<dd>Use this option to specify the full path to your hadoop installation location so that `hawq check` can validate HDFS settings. This option is not needed if the `HADOOP_HOME` environment variable is set.</dd>
 
 <dt>-\\\-stdout  </dt>
 <dd>Send collected host information from `hawq check` to standard output. No checks or validations are performed.</dd>
@@ -82,25 +82,25 @@ diskusage.monitor.mounts = /,/data1,/data2
 
 ## <a id="topic1__section5"></a>Examples
 
-Verify and validate the HAWQ platform settings by entering a host file and specifying the hadoop location:
+Verify and validate the HAWQ platform settings by entering a host file and specifying the full hadoop install path:
 
 ``` shell
-$ hawq check -f hostfile_hawq_check --hadoop ~/hadoop-2.0.0/
+$ hawq check -f hostfile_hawq_check --hadoop /usr/hdp/version/hadoop
 ```
 
 Verify and validate the HAWQ platform settings with HDFS HA enabled, YARN HA enabled and Kerberos enabled:
 
 ``` shell
-$ hawq check -f hostfile_hawq_check --hadoop ~/hadoop-2.0.0/ --hdfs-ha --yarn-ha --kerberos
+$ hawq check -f hostfile_hawq_check --hadoop /usr/hdp/version/hadoop --hdfs-ha --yarn-ha --kerberos
 ```
 
 Verify and validate the HAWQ platform settings with HDFS HA enabled, and Kerberos enabled:
 
 ``` shell
-$ hawq check -f hostfile_hawq_check --hadoop ~/hadoop-2.0.0/ --hdfs-ha --kerberos
+$ hawq check -f hostfile_hawq_check --hadoop /usr/hdp/version/hadoop --hdfs-ha --kerberos
 ```
 
-Save HAWQ platform settings to a zip file, when HADOOP\_HOME environment variable is set:
+Save HAWQ platform settings to a zip file, when the $HADOOP\_HOME environment variable is set:
 
 ``` shell
 $ hawq check -f hostfile_hawq_check --zipout  
@@ -115,7 +115,7 @@ $ hawq check --zipin hawq_check_timestamp.tar.gz
 View collected HAWQ platform settings:
 
 ``` shell
-$ hawq check -f hostfile_hawq_check --hadoop ~/hadoop-2.0.0/ --stdout
+$ hawq check -f hostfile_hawq_check --hadoop /usr/hdp/version/hadoop --stdout
 ```
 
 ## <a id="topic1__section6"></a>See Also

--- a/reference/cli/admin_utilities/hawqcheck.html.md.erb
+++ b/reference/cli/admin_utilities/hawqcheck.html.md.erb
@@ -7,9 +7,9 @@ Verifies and validates HAWQ platform settings.
 ## <a id="topic1__section2"></a>Synopsis
 
 ``` pre
-hawq check -f <hostfile_hawq_check>
+hawq check -f <hostfile_hawq_check> | (-h <hostname> | --host <hostname>)
+    --hadoop <hadoop_home> | --hadoop-home <hadoop_home>
     [--config <config_file>] 
-    [--hadoop <hadoop_home> | --hadoop-home <hadoop_home>]
     [--stdout | --zipout]
     [--kerberos] 
     [--hdfs-ha] 
@@ -42,6 +42,9 @@ diskusage.monitor.mounts = /,/data1,/data2
 
 <dt>-f \<hostfile\_hawq\_check\>  </dt>
 <dd>The name of a file that contains a list of hosts that `hawq check` uses to validate platform-specific settings. This file should contain a single host name for all hosts in your HAWQ system (master, standby master, and segments).</dd>
+
+<dt>-h, -\\\-host \<hostname\>  </dt>
+<dd>Specifies a single host on which platform-specific settings will be validated.</dd>
 
 <dt>-\\\-zipin \<hawq\_check\_zipfile\>  </dt>
 <dd>Use this option to decompress and check a .zip file created with the `--zipout` option. If you specify the `--zipin` option, `hawq check` performs validation tasks against the specified file.</dd>
@@ -85,19 +88,19 @@ diskusage.monitor.mounts = /,/data1,/data2
 Verify and validate the HAWQ platform settings by entering a host file and specifying the full hadoop install path:
 
 ``` shell
-$ hawq check -f hostfile_hawq_check --hadoop /usr/hdp/version/hadoop
+$ hawq check -f hostfile_hawq_check --hadoop /usr/hdp/<version>/hadoop
 ```
 
 Verify and validate the HAWQ platform settings with HDFS HA enabled, YARN HA enabled and Kerberos enabled:
 
 ``` shell
-$ hawq check -f hostfile_hawq_check --hadoop /usr/hdp/version/hadoop --hdfs-ha --yarn-ha --kerberos
+$ hawq check -f hostfile_hawq_check --hadoop /usr/local/hadoop-<version> --hdfs-ha --yarn-ha --kerberos
 ```
 
 Verify and validate the HAWQ platform settings with HDFS HA enabled, and Kerberos enabled:
 
 ``` shell
-$ hawq check -f hostfile_hawq_check --hadoop /usr/hdp/version/hadoop --hdfs-ha --kerberos
+$ hawq check -f hostfile_hawq_check --hadoop /usr/hdp/<version>/hadoop --hdfs-ha --kerberos
 ```
 
 Save HAWQ platform settings to a zip file, when the `$HADOOP_HOME` environment variable is set:
@@ -115,7 +118,7 @@ $ hawq check --zipin hawq_check_timestamp.tar.gz
 View collected HAWQ platform settings:
 
 ``` shell
-$ hawq check -f hostfile_hawq_check --hadoop /usr/hdp/version/hadoop --stdout
+$ hawq check -f hostfile_hawq_check --hadoop /usr/local/hadoop-<version> --stdout
 ```
 
 ## <a id="topic1__section6"></a>See Also

--- a/reference/cli/admin_utilities/hawqcheck.html.md.erb
+++ b/reference/cli/admin_utilities/hawqcheck.html.md.erb
@@ -8,7 +8,7 @@ Verifies and validates HAWQ platform settings.
 
 ``` pre
 hawq check -f <hostfile_hawq_check> | (-h <hostname> | --host <hostname>)
-    --hadoop <hadoop_home> | --hadoop-home <hadoop_home>
+    [--hadoop <hadoop_home> | --hadoop-home <hadoop_home>]
     [--config <config_file>] 
     [--stdout | --zipout]
     [--kerberos] 

--- a/reference/cli/admin_utilities/hawqcheck.html.md.erb
+++ b/reference/cli/admin_utilities/hawqcheck.html.md.erb
@@ -25,7 +25,7 @@ hawq check -?
 
 ## <a id="topic1__section3"></a>Description
 
-The `hawq check` utility determines the platform on which you are running HAWQ and validates various platform-specific configuration settings as well as HAWQ and HDFS-specific configuration settings. In order to perform HAWQ configuration checks, make sure HAWQ has been already started and `hawq config` works. For HDFS checks, you should either set the HADOOP\_HOME environment variable or provide the hadoop installation location using `--hadoop` option.
+The `hawq check` utility determines the platform on which you are running HAWQ and validates various platform-specific configuration settings as well as HAWQ and HDFS-specific configuration settings. In order to perform HAWQ configuration checks, make sure HAWQ has been already started and `hawq config` works. For HDFS checks, you should either set the `$HADOOP_HOME` environment variable or provide the full path to the hadoop installation location using the `--hadoop` option.
 
 The `hawq check` utility can use a host file or a file previously created with the `--zipout `option to validate platform settings. If `GPCHECK_ERROR` displays, one or more validation checks failed. You can also use `hawq check` to gather and view platform settings on hosts without running validation checks. When running checks, `hawq check` compares your actual configuration setting with an expected value listed in a config file (`$GPHOME/etc/hawq_check.cnf` by default). You must modify your configuration values for "mount.points" and "diskusage.monitor.mounts" to reflect the actual mount points you want to check, as a comma-separated list. Otherwise, the utility only checks the root directory, which may not be helpful.
 
@@ -54,7 +54,7 @@ diskusage.monitor.mounts = /,/data1,/data2
 <dd>The name of a configuration file to use instead of the default file `$GPHOME/etc/hawq_check.cnf`.</dd>
 
 <dt>-\\\-hadoop, -\\\-hadoop-home \<hadoop\_home\>  </dt>
-<dd>Use this option to specify the full path to your hadoop installation location so that `hawq check` can validate HDFS settings. This option is not needed if the `HADOOP_HOME` environment variable is set.</dd>
+<dd>Use this option to specify the full path to your hadoop installation location so that `hawq check` can validate HDFS settings. This option is not needed if the `$HADOOP_HOME` environment variable is set.</dd>
 
 <dt>-\\\-stdout  </dt>
 <dd>Send collected host information from `hawq check` to standard output. No checks or validations are performed.</dd>
@@ -100,7 +100,7 @@ Verify and validate the HAWQ platform settings with HDFS HA enabled, and Kerbero
 $ hawq check -f hostfile_hawq_check --hadoop /usr/hdp/version/hadoop --hdfs-ha --kerberos
 ```
 
-Save HAWQ platform settings to a zip file, when the $HADOOP\_HOME environment variable is set:
+Save HAWQ platform settings to a zip file, when the `$HADOOP_HOME` environment variable is set:
 
 ``` shell
 $ hawq check -f hostfile_hawq_check --zipout  


### PR DESCRIPTION
some cleanup to documentation for "hawq check" command.  fixes the documentation part of HAWQ-1056.

- add -h, --host <hostname> option
- clarify value of --hadoop, --hadoop-home option <hadoop_home> value should be the full install path to hadoop
- modify the examples to use relevant values for hadoop_home