### PR TITLE
improve install docs with passwordless ssh info

### DIFF
--- a/admin/ClusterExpansion.html.md.erb
+++ b/admin/ClusterExpansion.html.md.erb
@@ -20,7 +20,7 @@ There are several recommendations to keep in mind when modifying the size of you
 
 ## <a id="task_hawq_expand"></a>Adding a New Node to an Existing HAWQ Cluster 
 
-The following procedure describes the steps required to add a node to an existing HAWQ cluster.  First ensure that the new node has been configured per the instructions in [Apache HAWQ System Requirements](/20/requirements/system-requirements.html) and [Select HAWQ Host Machines](/20/install/select-hosts.html).
+The following procedure describes the steps required to add a node to an existing HAWQ cluster.  First ensure that the new node has been configured per the instructions found in [Apache HAWQ System Requirements](/20/requirements/system-requirements.html) and [Select HAWQ Host Machines](/20/install/select-hosts.html).
 
 For example purposes in this procedure, we are adding a new node named `sdw4`.
 
@@ -71,7 +71,7 @@ For example purposes in this procedure, we are adding a new node named `sdw4`.
         $ hawq ssh-exkeys -e hawq_hosts -x new_hosts
         ```
 
-    8.  (Optional) Turn off temporary password-based authentication as described in [Apache HAWQ System Requirements](/20/requirements/system-requirements.html#topic_pwdlessssh).
+    8.  (Optional) If you enabled temporary password-based authentication while preparing/configuring your new HAWQ host system, turn off password-based authentication as described in [Apache HAWQ System Requirements](/20/requirements/system-requirements.html#topic_pwdlessssh).
 
     8.  After setting up passwordless ssh, you can execute the following hawq command to check the target machine's configuration.
 

--- a/admin/ClusterExpansion.html.md.erb
+++ b/admin/ClusterExpansion.html.md.erb
@@ -20,7 +20,7 @@ There are several recommendations to keep in mind when modifying the size of you
 
 ## <a id="task_hawq_expand"></a>Adding a New Node to an Existing HAWQ Cluster 
 
-The following procedure describes the steps required to add a node to an existing HAWQ cluster.
+The following procedure describes the steps required to add a node to an existing HAWQ cluster.  First ensure that the new node has been configured per the instructions in [Apache HAWQ System Requirements](/20/requirements/system-requirements.html) and [Select HAWQ Host Machines](/20/install/select-hosts.html).
 
 For example purposes in this procedure, we are adding a new node named `sdw4`.
 
@@ -70,6 +70,8 @@ For example purposes in this procedure, we are adding a new node named `sdw4`.
         ```shell
         $ hawq ssh-exkeys -e hawq_hosts -x new_hosts
         ```
+
+    8.  (Optional) Turn off temporary password-based authentication as described in [Apache HAWQ System Requirements](/20/requirements/system-requirements.html#topic_pwdlessssh).
 
     8.  After setting up passwordless ssh, you can execute the following hawq command to check the target machine's configuration.
 

--- a/admin/ambari-admin.html.md.erb
+++ b/admin/ambari-admin.html.md.erb
@@ -160,6 +160,8 @@ There are several recommendations to keep in mind when modifying the size of you
 -  If you are using hash tables, consider updating the `default_hash_table_bucket_number` server configuration parameter to a larger value after expanding the cluster but before redistributing the hash tables.
 
 ### Procedure
+First ensure that the new node(s) has been configured per the instructions in [Apache HAWQ System Requirements](/20/requirements/system-requirements.html) and [Select HAWQ Host Machines](/20/install/select-hosts.html).
+
 1.  If you have any user-defined function (UDF) libraries installed in your existing HAWQ cluster, install them on the new node(s) that you want to add to the HAWQ cluster.
 2.  Access the Ambari web console at http://ambari.server.hostname:8080, and login as the "admin" user. \(The default password is also "admin".\)
 3.  Click **HAWQ** in the list of installed services.
@@ -201,6 +203,8 @@ There are several recommendations to keep in mind when modifying the size of you
 
     **Note:** The redistribution of table data can take a significant amount of time.
 22.  (Optional.) If you changed the **Exchange SSH Keys** property value before adding the host(s), change the value back to `false` after Ambari exchanges keys with the new hosts. This prevents Ambari from exchanging keys with all hosts every time the HAWQ master is started or restarted.
+
+23.  (Optional.) Turn off temporary password-based authentication as described in [Apache HAWQ System Requirements](/20/requirements/system-requirements.html#topic_pwdlessssh).
 
 #### <a id="manual-config-steps"></a>Manually Updating the HAWQ Configuration
 If you need to expand your HAWQ cluster without restarting the HAWQ service, follow these steps to manually apply the new HAWQ configuration. (Use these steps *instead* of following Step 7 in the above procedure.):

--- a/admin/ambari-admin.html.md.erb
+++ b/admin/ambari-admin.html.md.erb
@@ -160,7 +160,7 @@ There are several recommendations to keep in mind when modifying the size of you
 -  If you are using hash tables, consider updating the `default_hash_table_bucket_number` server configuration parameter to a larger value after expanding the cluster but before redistributing the hash tables.
 
 ### Procedure
-First ensure that the new node(s) has been configured per the instructions in [Apache HAWQ System Requirements](/20/requirements/system-requirements.html) and [Select HAWQ Host Machines](/20/install/select-hosts.html).
+First ensure that the new node(s) has been configured per the instructions found in [Apache HAWQ System Requirements](/20/requirements/system-requirements.html) and [Select HAWQ Host Machines](/20/install/select-hosts.html).
 
 1.  If you have any user-defined function (UDF) libraries installed in your existing HAWQ cluster, install them on the new node(s) that you want to add to the HAWQ cluster.
 2.  Access the Ambari web console at http://ambari.server.hostname:8080, and login as the "admin" user. \(The default password is also "admin".\)
@@ -204,7 +204,7 @@ First ensure that the new node(s) has been configured per the instructions in [A
     **Note:** The redistribution of table data can take a significant amount of time.
 22.  (Optional.) If you changed the **Exchange SSH Keys** property value before adding the host(s), change the value back to `false` after Ambari exchanges keys with the new hosts. This prevents Ambari from exchanging keys with all hosts every time the HAWQ master is started or restarted.
 
-23.  (Optional.) Turn off temporary password-based authentication as described in [Apache HAWQ System Requirements](/20/requirements/system-requirements.html#topic_pwdlessssh).
+23.  (Optional.) If you enabled temporary password-based authentication while preparing/configuring your HAWQ host systems, turn off password-based authentication as described in [Apache HAWQ System Requirements](/20/requirements/system-requirements.html#topic_pwdlessssh).
 
 #### <a id="manual-config-steps"></a>Manually Updating the HAWQ Configuration
 If you need to expand your HAWQ cluster without restarting the HAWQ service, follow these steps to manually apply the new HAWQ configuration. (Use these steps *instead* of following Step 7 in the above procedure.):

--- a/install/aws-config.html.md.erb
+++ b/install/aws-config.html.md.erb
@@ -29,7 +29,6 @@ Instance store-backed storage is generally better performing than EBS and recomm
 **Note** EC2 *instance store* provides temporary block-level storage. This storage is located on disks that are physically attached to the host computer. While instance store provides high performance, powering off the instance causes data loss. Soft reboots preserve instance store data. 
      
 Virtual devices for instance store volumes for HAWQ EC2 instance store instances are named `ephemeralN` (where *N* varies based on instance type). CentOS instance store block device are named `/dev/xvdletter` (where *letter* is a lower case letter of the alphabet).
-  
 
 ### <a id="topic_cfgplacegrp"></a>Configure Placement Group 
 

--- a/install/aws-config.html.md.erb
+++ b/install/aws-config.html.md.erb
@@ -102,8 +102,11 @@ $ ssh -i my-test.pem user1@192.0.2.0
 
 After launching your HAWQ instance, you will connect to and configure the instance. The  *Instances* page of the EC2 Console lists the running instances and their associated network access information.
 
-Before installing HAWQ, set up the EC2 instances as you would local host server machines. Configure the host operating system, configure host network information (for example, update the `/etc/hosts` file), set operating system parameters, and install operating system packages. For information about how to prepare your operating system environment for HAWQ, see [Select HAWQ Host Machines](../install/select-hosts.html).
+Before installing HAWQ, set up the EC2 instances as you would local host server machines. Configure the host operating system, configure host network information (for example, update the `/etc/hosts` file), set operating system parameters, and install operating system packages. For information about how to prepare your operating system environment for HAWQ, see [Apache HAWQ System Requirements](../requirements/system-requirements.html) and [Select HAWQ Host Machines](../install/select-hosts.html).
 
+###Passwordless SSH Configuration<a id="topic_pwdlessssh_cc"></a>
+
+HAWQ hosts will be configured during the installation process to use passwordless SSH for intra-cluster communications. Temporary password-based authentication must be enabled on each HAWQ host in preparation for this configuration. Password authentication is typically disabled by default in cloud images. Update the cloud configuration in `/etc/cloud/cloud.cfg` to enable password authentication in your AMI(s). Set `ssh_pwauth: True` in this file. If desired, disable password authentication after HAWQ installation by setting the property back to `False`.
   
 ##References<a id="topic_hgz_zwy_bv"></a>
 

--- a/requirements/system-requirements.html.md.erb
+++ b/requirements/system-requirements.html.md.erb
@@ -173,6 +173,51 @@ If this system uses YARN for resource management, you would set `yarn.nodemanage
 
 If this system uses the default HAWQ resource manager, you would set `hawq_rm_memory_limit_perseg` = `RAM - NON_HAWQ_MEMORY` = 8 GB - 7GB = 1.
 
+## <a id="topic_pwdlessssh"></a>Passwordless SSH Configuration
+
+HAWQ hosts will be configured to use passwordless SSH for intra-cluster communications during the installation process. Temporary password-based authentication must be enabled on each HAWQ host in preparation for this configuration.
+
+1. Install the SSH server if not already configured on the HAWQ system:
+    
+    ``` shell
+    $ yum list installed | grep openssh-server
+    $ yum -y install openssh-server
+    ```
+    
+2. Update the host's SSH configuration to allow password-based authentication. Edit the SSH config file and change the `PasswordAuthentication` configuration value from `no` to `yes`:
+    
+    ``` shell
+    $ sudo vi /etc/ssh/sshd_config
+    ```
+    
+    ```
+    PasswordAuthentication yes
+    ```
+
+3. Restart SSH:
+    
+    ``` shell
+    $ sudo /etc/init.d/sshd restart
+    ```
+
+*After installation is complete*, you may choose to turn off the temporary password-based authentication configured in the previous steps:
+
+1. Open the SSH `/etc/ssh/sshd_config` file in a text editor and update/uncomment the following configuration options.
+    
+    ```
+    RSAAuthentication yes
+    PasswordAuthentication no
+    PubkeyAuthentication yes
+    AuthorizedKeyFile  .ssh/authorized_keys
+    ```
+
+2.  Restart SSH:
+    
+    ``` shell
+    $ sudo /etc/init.d/sshd restart
+    ```
+ 
+
 ## <a id="topic_bsm_hhv_2v"></a>Disk Requirements
 
 -   2GB per host for HAWQ installation. 

--- a/requirements/system-requirements.html.md.erb
+++ b/requirements/system-requirements.html.md.erb
@@ -178,43 +178,40 @@ If this system uses the default HAWQ resource manager, you would set `hawq_rm_me
 HAWQ hosts will be configured to use passwordless SSH for intra-cluster communications during the installation process. Temporary password-based authentication must be enabled on each HAWQ host in preparation for this configuration.
 
 1. Install the SSH server if not already configured on the HAWQ system:
-    
+
     ``` shell
     $ yum list installed | grep openssh-server
     $ yum -y install openssh-server
     ```
-    
+
 2. Update the host's SSH configuration to allow password-based authentication. Edit the SSH config file and change the `PasswordAuthentication` configuration value from `no` to `yes`:
-    
+
     ``` shell
     $ sudo vi /etc/ssh/sshd_config
     ```
-    
+
     ```
     PasswordAuthentication yes
     ```
 
 3. Restart SSH:
-    
+
     ``` shell
-    $ sudo /etc/init.d/sshd restart
+    $ sudo service sshd restart
     ```
 
 *After installation is complete*, you may choose to turn off the temporary password-based authentication configured in the previous steps:
 
-1. Open the SSH `/etc/ssh/sshd_config` file in a text editor and update/uncomment the following configuration options.
+1. Open the SSH `/etc/ssh/sshd_config` file in a text editor and update the configuration option you enabled in step 2 above:
     
     ```
-    RSAAuthentication yes
     PasswordAuthentication no
-    PubkeyAuthentication yes
-    AuthorizedKeyFile  .ssh/authorized_keys
     ```
 
 2.  Restart SSH:
     
     ``` shell
-    $ sudo /etc/init.d/sshd restart
+    $ sudo service sshd restart
     ```
  
 


### PR DESCRIPTION
include instructions to temporarily enable password authentication before HAWQ installation.