### PR TITLE
HAWQ-1096 - add content for hawq built-in languages

### DIFF
--- a/plext/UsingProceduralLanguages.html.md.erb
+++ b/plext/UsingProceduralLanguages.html.md.erb
@@ -1,13 +1,16 @@
 ---
-title: Using Procedural Languages and Extensions in HAWQ
+title: Using Languages and Extensions in HAWQ
 ---
 
-HAWQ allows user-defined functions to be written in other languages besides SQL and C. These other languages are generically called *procedural languages* (PLs).
+HAWQ supports user-defined functions created with the SQL and C built-in languages, including supporting user-defined aliases for internal functions.
+
+HAWQ also allows user-defined functions to be written in languages other than SQL and C. These other languages are generically called *procedural languages* (PLs).
 
 For a function written in a procedural language, the database server has no built-in knowledge about how to interpret the function's source text. Instead, the task is passed to a special handler that knows the details of the language. The handler could either do all the work of parsing, syntax analysis, execution, and so on itself, or it could serve as "glue" between HAWQ and an existing implementation of a programming language. The handler itself is a C language function compiled into a shared object and loaded on demand, just like any other C function.
 
 This chapter describes the following:
 
+-   <a href="builtin_langs.html">Using HAWQ Built-In Languages</a>
 -   <a href="using_pljava.html">Using PL/Java</a>
 -   <a href="using_plperl.html">Using PL/Perl</a>
 -   <a href="using_plpgsql.html">Using PL/pgSQL</a>

--- a/plext/UsingProceduralLanguages.html.md.erb
+++ b/plext/UsingProceduralLanguages.html.md.erb
@@ -4,11 +4,11 @@ title: Using Languages and Extensions in HAWQ
 
 HAWQ supports user-defined functions created with the SQL and C built-in languages, including supporting user-defined aliases for internal functions.
 
-HAWQ also allows user-defined functions to be written in languages other than SQL and C. These other languages are generically called *procedural languages* (PLs).
+HAWQ also supports user-defined functions written in languages other than SQL and C. These other languages are generically called *procedural languages* (PLs) and are extensions to the core HAWQ functionality. HAWQ specifically supports the PL/Java, PL/Perl, PL/pgSQL, PL/Python, and PL/R procedural languages. 
 
-For a function written in a procedural language, the database server has no built-in knowledge about how to interpret the function's source text. Instead, the task is passed to a special handler that knows the details of the language. The handler could either do all the work of parsing, syntax analysis, execution, and so on itself, or it could serve as "glue" between HAWQ and an existing implementation of a programming language. The handler itself is a C language function compiled into a shared object and loaded on demand, just like any other C function.
+HAWQ additionally provides the `pgcrypto` extension for password hashing and data encryption.
 
-This chapter describes the following:
+This chapter describes these languages and extensions:
 
 -   <a href="builtin_langs.html">Using HAWQ Built-In Languages</a>
 -   <a href="using_pljava.html">Using PL/Java</a>

--- a/plext/UsingProceduralLanguages.html.md.erb
+++ b/plext/UsingProceduralLanguages.html.md.erb
@@ -2,7 +2,7 @@
 title: Using Languages and Extensions in HAWQ
 ---
 
-HAWQ supports user-defined functions created with the SQL and C built-in languages, including supporting user-defined aliases for internal functions.
+HAWQ supports user-defined functions that are created with the SQL and C built-in languages, and also supports user-defined aliases for internal functions.
 
 HAWQ also supports user-defined functions written in languages other than SQL and C. These other languages are generically called *procedural languages* (PLs) and are extensions to the core HAWQ functionality. HAWQ specifically supports the PL/Java, PL/Perl, PL/pgSQL, PL/Python, and PL/R procedural languages. 
 

--- a/plext/builtin_langs.html.md.erb
+++ b/plext/builtin_langs.html.md.erb
@@ -13,7 +13,7 @@ Support for SQL, internal, and C language user-defined functions is enabled by d
 
 ## <a id="builtinsql"></a>SQL
 
-SQL functions execute an arbitrary list of SQL statements. The SQL statements in the body of an SQL function must be separated by semicolons. The final statement in a non-void-returning SQL function must be a `SELECT` that returns data of the type specified by the function's return type. The function will return a single or set of rows corresponding to this last SQL query.
+SQL functions execute an arbitrary list of SQL statements. The SQL statements in the body of an SQL function must be separated by semicolons. The final statement in a non-void-returning SQL function must be a [SELECT](../reference/sql/SELECT.html) that returns data of the type specified by the function's return type. The function will return a single or set of rows corresponding to this last SQL query.
 
 The following example creates and calls an SQL function to count the number of rows of the database named `orders`:
 
@@ -33,19 +33,19 @@ For additional information on creating SQL functions, refer to [Query Language (
 
 ## <a id="builtininternal"></a>Internal
 
-Many HAWQ internal functions are written in C. These functions are declared during initialization of the database cluster and statically linked to the HAWQ server.
+Many HAWQ internal functions are written in C. These functions are declared during initialization of the database cluster and statically linked to the HAWQ server. See [Built-in Functions and Operators](../query/functions-operators.html#topic29) for detailed information on HAWQ internal functions.
 
 While users cannot define new internal functions, they can create aliases for existing internal functions.
 
-The following example creates a new function named `to_upper` that will be an alias for the `upper` internal HAWQ function:
+The following example creates a new function named `all_caps` that will be defined as an alias for the `upper` HAWQ internal function:
 
 
 ``` sql
-gpadmin=# CREATE FUNCTION to_upper (text) RETURNS text AS 'upper'
+gpadmin=# CREATE FUNCTION all_caps (text) RETURNS text AS 'upper'
             LANGUAGE internal STRICT;
 CREATE FUNCTION
-gpadmin=# SELECT to_upper('change me');
- to_upper  
+gpadmin=# SELECT all_caps('change me');
+ all_caps  
 -----------
  CHANGE ME
 (1 row)
@@ -58,9 +58,15 @@ For more information on aliasing internal functions, refer to [Internal Function
 
 User-defined functions written in C must be compiled into shared libraries to be loaded by the HAWQ server on demand. This dynamic loading distinguishes C language functions from internal functions that are written in C.
 
-The `CREATE FUNCTION` call for a user-defined C function must include both the name of the shared library and the name of the function.
+The [CREATE FUNCTION](../reference/sql/CREATE-FUNCTION.html) call for a user-defined C function must include both the name of the shared library and the name of the function.
 
-If an absolute path to the shared library is not provided, an attempt is made to locate the library relative to: the HAWQ PostgreSQL library directory (obtained via the `pg_config --pkglibdir` command), the `dynamic_library_path` configuration value, and the current working directory, in that order. 
+If an absolute path to the shared library is not provided, an attempt is made to locate the library relative to the: 
+
+1. HAWQ PostgreSQL library directory (obtained via the `pg_config --pkglibdir` command)
+2. `dynamic_library_path` configuration value
+3. current working directory
+
+in that order. 
 
 Example:
 

--- a/plext/builtin_langs.html.md.erb
+++ b/plext/builtin_langs.html.md.erb
@@ -1,0 +1,104 @@
+---
+title: Using HAWQ Built-In Languages
+---
+
+This section provides an introduction to using the HAWQ built-in languages.
+
+HAWQ supports user-defined functions created with the SQL and C built-in languages. HAWQ also supports user-defined aliases for internal functions.
+
+
+## <a id="enablebuiltin"></a>Enabling Built-in Language Support
+
+Support for SQL, internal, and C language user-defined functions is enabled by default for all HAWQ databases.
+
+## <a id="builtinsql"></a>SQL
+
+SQL functions execute an arbitrary list of SQL statements. The SQL statements in the body of an SQL function must be separated by semicolons. The final statement in a non-void-returning SQL function must be a `SELECT` that returns data of the type specified by the function's return type. The function will return a single or set of rows corresponding to this last SQL query.
+
+The following example creates and calls an SQL function to count the number of rows of the database named `orders`:
+
+``` sql
+gpadmin=# CREATE FUNCTION count_orders() RETURNS bigint AS $$
+ SELECT count(*) FROM orders;
+$$ LANGUAGE SQL;
+CREATE FUNCTION
+gpadmin=# select count_orders();
+ my_count 
+----------
+   830513
+(1 row)
+```
+
+For additional information on creating SQL functions, refer to [Query Language (SQL) Functions](https://www.postgresql.org/docs/8.2/static/xfunc-sql.html) in the PostgreSQL documentation.
+
+## <a id="builtininternal"></a>Internal
+
+Many HAWQ internal functions are written in C. These functions are declared during initialization of the database cluster and statically linked to the HAWQ server.
+
+While users cannot define new internal functions, they can create aliases for existing internal functions.
+
+The following example creates a new function named `to_upper` that will be an alias for the `upper` internal HAWQ function:
+
+
+``` sql
+gpadmin=# CREATE FUNCTION to_upper (text) RETURNS text AS 'upper'
+            LANGUAGE internal STRICT;
+CREATE FUNCTION
+gpadmin=# SELECT to_upper('change me');
+ to_upper  
+-----------
+ CHANGE ME
+(1 row)
+
+```
+
+For more information on aliasing internal functions, refer to [Internal Functions](https://www.postgresql.org/docs/8.2/static/xfunc-internal.html) in the PostgreSQL documentation.
+
+## <a id="builtininternal"></a>C
+
+User-defined functions written in C must be compiled into shared libraries to be loaded by the HAWQ server on demand. This dynamic loading distinguishes C language functions from internal functions that are written in C.
+
+The `CREATE FUNCTION` call for a user-defined C function must include both the name of the shared library and the name of the function.
+
+If an absolute path to the shared library is not provided, an attempt is made to locate the library relative to: the HAWQ PostgreSQL library directory (obtained via the `pg_config --pkglibdir` command), the `dynamic_library_path` configuration value, and the current working directory, in that order. 
+
+Example:
+
+``` c
+#include "postgres.h"
+#include "fmgr.h"
+
+#ifdef PG_MODULE_MAGIC
+PG_MODULE_MAGIC;
+#endif
+
+PG_FUNCTION_INFO_V1(double_it);
+         
+Datum
+double_it(PG_FUNCTION_ARGS)
+{
+    int32   arg = PG_GETARG_INT32(0);
+
+    PG_RETURN_INT64(arg + arg);
+}
+```
+
+If the above function is compiled into a shared object named `libdoubleit.so` located in `/share/libs`, you would register and invoke the function with HAWQ as follows:
+
+``` sql
+gpadmin=# CREATE FUNCTION double_it(integer) RETURNS integer
+            AS '/share/libs/libdoubleit', 'double_it'
+            LANGUAGE C STRICT;
+CREATE FUNCTION
+gpadmin=# SELECT double_it(27);
+ double_it 
+-----------
+        54
+(1 row)
+
+```
+
+The shared library `.so` extension may be omitted.
+
+For additional information on using the C language to create functions, refer to [C-Language Functions](https://www.postgresql.org/docs/8.2/static/xfunc-c.html) in the PostgreSQL documentation.
+

--- a/plext/builtin_langs.html.md.erb
+++ b/plext/builtin_langs.html.md.erb
@@ -9,13 +9,13 @@ HAWQ supports user-defined functions created with the SQL and C built-in languag
 
 ## <a id="enablebuiltin"></a>Enabling Built-in Language Support
 
-Support for SQL, internal, and C language user-defined functions is enabled by default for all HAWQ databases.
+Support for SQL and C language user-defined functions and aliasing of internal functions is enabled by default for all HAWQ databases.
 
-## <a id="builtinsql"></a>SQL
+## <a id="builtinsql"></a>Defining SQL Functions
 
-SQL functions execute an arbitrary list of SQL statements. The SQL statements in the body of an SQL function must be separated by semicolons. The final statement in a non-void-returning SQL function must be a [SELECT](../reference/sql/SELECT.html) that returns data of the type specified by the function's return type. The function will return a single or set of rows corresponding to this last SQL query.
+SQL functions execute an arbitrary list of SQL statements. The SQL statements in the body of a SQL function must be separated by semicolons. The final statement in a non-void-returning SQL function must be a [SELECT](../reference/sql/SELECT.html) that returns data of the type specified by the function's return type. The function will return a single or set of rows corresponding to this last SQL query.
 
-The following example creates and calls an SQL function to count the number of rows of the database named `orders`:
+The following example creates and calls a SQL function to count the number of rows of the database named `orders`:
 
 ``` sql
 gpadmin=# CREATE FUNCTION count_orders() RETURNS bigint AS $$
@@ -29,15 +29,15 @@ gpadmin=# select count_orders();
 (1 row)
 ```
 
-For additional information on creating SQL functions, refer to [Query Language (SQL) Functions](https://www.postgresql.org/docs/8.2/static/xfunc-sql.html) in the PostgreSQL documentation.
+For additional information about creating SQL functions, refer to [Query Language (SQL) Functions](https://www.postgresql.org/docs/8.2/static/xfunc-sql.html) in the PostgreSQL documentation.
 
-## <a id="builtininternal"></a>Internal
+## <a id="builtininternal"></a>Aliasing Internal Functions
 
-Many HAWQ internal functions are written in C. These functions are declared during initialization of the database cluster and statically linked to the HAWQ server. See [Built-in Functions and Operators](../query/functions-operators.html#topic29) for detailed information on HAWQ internal functions.
+Many HAWQ internal functions are written in C. These functions are declared during initialization of the database cluster and statically linked to the HAWQ server. See [Built-in Functions and Operators](../query/functions-operators.html#topic29) for detailed information about HAWQ internal functions.
 
-While users cannot define new internal functions, they can create aliases for existing internal functions.
+You cannot define new internal functions, but you can create aliases for existing internal functions.
 
-The following example creates a new function named `all_caps` that will be defined as an alias for the `upper` HAWQ internal function:
+The following example creates a new function named `all_caps` that is an alias for the `upper` HAWQ internal function:
 
 
 ``` sql
@@ -52,11 +52,11 @@ gpadmin=# SELECT all_caps('change me');
 
 ```
 
-For more information on aliasing internal functions, refer to [Internal Functions](https://www.postgresql.org/docs/8.2/static/xfunc-internal.html) in the PostgreSQL documentation.
+For more information about aliasing internal functions, refer to [Internal Functions](https://www.postgresql.org/docs/8.2/static/xfunc-internal.html) in the PostgreSQL documentation.
 
-## <a id="builtininternal"></a>C
+## <a id="builtinc_lang"></a>Defining C Functions
 
-User-defined functions written in C must be compiled into shared libraries to be loaded by the HAWQ server on demand. This dynamic loading distinguishes C language functions from internal functions that are written in C.
+You must compile user-defined functions written in C into shared libraries so that the HAWQ server can load them on demand. This dynamic loading distinguishes C language functions from internal functions that are written in C.
 
 The [CREATE FUNCTION](../reference/sql/CREATE-FUNCTION.html) call for a user-defined C function must include both the name of the shared library and the name of the function.
 
@@ -106,5 +106,5 @@ gpadmin=# SELECT double_it_c(27);
 
 The shared library `.so` extension may be omitted.
 
-For additional information on using the C language to create functions, refer to [C-Language Functions](https://www.postgresql.org/docs/8.2/static/xfunc-c.html) in the PostgreSQL documentation.
+For additional information about using the C language to create functions, refer to [C-Language Functions](https://www.postgresql.org/docs/8.2/static/xfunc-c.html) in the PostgreSQL documentation.
 

--- a/plext/builtin_langs.html.md.erb
+++ b/plext/builtin_langs.html.md.erb
@@ -86,11 +86,11 @@ double_it(PG_FUNCTION_ARGS)
 If the above function is compiled into a shared object named `libdoubleit.so` located in `/share/libs`, you would register and invoke the function with HAWQ as follows:
 
 ``` sql
-gpadmin=# CREATE FUNCTION double_it(integer) RETURNS integer
+gpadmin=# CREATE FUNCTION double_it_c(integer) RETURNS integer
             AS '/share/libs/libdoubleit', 'double_it'
             LANGUAGE C STRICT;
 CREATE FUNCTION
-gpadmin=# SELECT double_it(27);
+gpadmin=# SELECT double_it_c(27);
  double_it 
 -----------
         54


### PR DESCRIPTION
add content for sql, c, and internal hawq built in languages