### PR TITLE
subnav changes for removing greenplum references

### DIFF
--- a/master_middleman/source/subnavs/apache-hawq-nav.erb
+++ b/master_middleman/source/subnavs/apache-hawq-nav.erb
@@ -248,7 +248,7 @@
                   <li><a href="/20/datamgmt/load/g-handling-errors-ext-table-data.html">Handling Errors in External Table Data</a></li>
                 </ul>
               </li>
-              <li class="has_submenu"><a href="/20/datamgmt/load/g-using-the-greenplum-parallel-file-server--gpfdist-.html">Using the Greenplum Parallel File Server (gpfdist)</a>
+              <li class="has_submenu"><a href="/20/datamgmt/load/g-using-the-greenplum-parallel-file-server--gpfdist-.html">Using the HAWQ File Server (gpfdist)</a>
                 <ul>
                   <li><a href="/20/datamgmt/load/g-about-gpfdist-setup-and-performance.html">About gpfdist Setup and Performance</a></li>
                   <li><a href="/20/datamgmt/load/g-controlling-segment-parallelism.html">Controlling Segment Parallelism</a></li>

--- a/master_middleman/source/subnavs/apache-hawq-nav.erb
+++ b/master_middleman/source/subnavs/apache-hawq-nav.erb
@@ -166,7 +166,7 @@
             <a href="/20/clientaccess/g-supported-client-applications.html">Supported Client Applications</a>
           </li>
           <li>
-            <a href="/20/clientaccess/g-greenplum-database-client-applications.html">HAWQ Client Applications</a>
+            <a href="/20/clientaccess/g-hawq-database-client-applications.html">HAWQ Client Applications</a>
           </li>
           <li>
             <a href="/20/clientaccess/g-connecting-with-psql.html">Connecting with psql</a>
@@ -248,7 +248,7 @@
                   <li><a href="/20/datamgmt/load/g-handling-errors-ext-table-data.html">Handling Errors in External Table Data</a></li>
                 </ul>
               </li>
-              <li class="has_submenu"><a href="/20/datamgmt/load/g-using-the-greenplum-parallel-file-server--gpfdist-.html">Using the HAWQ File Server (gpfdist)</a>
+              <li class="has_submenu"><a href="/20/datamgmt/load/g-using-the-hawq-file-server--gpfdist-.html">Using the HAWQ File Server (gpfdist)</a>
                 <ul>
                   <li><a href="/20/datamgmt/load/g-about-gpfdist-setup-and-performance.html">About gpfdist Setup and Performance</a></li>
                   <li><a href="/20/datamgmt/load/g-controlling-segment-parallelism.html">Controlling Segment Parallelism</a></li>
@@ -289,11 +289,11 @@
               <li><a href="/20/datamgmt/load/g-loading-data-with-copy.html">Loading Data with COPY</a></li>
               <li><a href="/20/datamgmt/load/g-running-copy-in-single-row-error-isolation-mode.html">Running COPY in Single Row Error Isolation Mode</a></li>
               <li><a href="/20/datamgmt/load/g-optimizing-data-load-and-query-performance.html">Optimizing Data Load and Query Performance</a></li>
-              <li class="has_submenu"><a href="/20/datamgmt/load/g-unloading-data-from-greenplum-database.html">Unloading Data from HAWQ</a>
+              <li class="has_submenu"><a href="/20/datamgmt/load/g-unloading-data-from-hawq-database.html">Unloading Data from HAWQ</a>
                 <ul>
                   <li class="has_submenu"><a href="/20/datamgmt/load/g-defining-a-file-based-writable-external-table.html">Defining a File-Based Writable External Table</a>
                     <ul>
-                      <li><a href="/20/datamgmt/load/g-example-greenplum-file-server-gpfdist.html">Example - HAWQ file server (gpfdist)</a></li>
+                      <li><a href="/20/datamgmt/load/g-example-hawq-file-server-gpfdist.html">Example - HAWQ file server (gpfdist)</a></li>
                     </ul>
                   </li>
                   <li class="has_submenu"><a href="/20/datamgmt/load/g-defining-a-command-based-writable-external-web-table.html">Defining a Command-Based Writable External Web Table</a>


### PR DESCRIPTION
update subnav titles to remove greenplum references.

update subnav source files names to new names - hawq replaces greenplum.