### PR TITLE
HAWQ-1219 - add ao and parquet relstorage types

### DIFF
--- a/reference/catalog/pg_class.html.md.erb
+++ b/reference/catalog/pg_class.html.md.erb
@@ -125,7 +125,7 @@ The system catalog table `pg_class` catalogs tables and most everything else tha
 <td>char</td>
 <td> </td>
 <td>The storage mode of a table
-<p><code class="ph codeph">h</code> = heap, <code class="ph codeph">v</code> = virtual, <code class="ph codeph">x</code>= external table.</p></td>
+<p><code class="ph codeph">a</code> = append-only, <code class="ph codeph">h</code> = heap, <code class="ph codeph">p</code> = append-only parquet, <code class="ph codeph">v</code> = virtual, <code class="ph codeph">x</code>= external table.</p></td>
 </tr>
 <tr class="even">
 <td><code class="ph codeph">relnatts</code></td>


### PR DESCRIPTION
add parquet and append only restorage types to pg_class reference page (table)