### PR TITLE
HAWQ-1209 - add subnav for setting up hawq op env

### DIFF
--- a/master_middleman/source/subnavs/apache-hawq-nav.erb
+++ b/master_middleman/source/subnavs/apache-hawq-nav.erb
@@ -77,6 +77,9 @@
             <a href="/20/admin/RunningHAWQ.html">Overview</a>
           </li>
           <li>
+            <a href="/20/admin/setuphawqopenv.html">Introducing the HAWQ Operating Environment</a>
+          </li>
+          <li>
             <a href="/20/admin/ambari-admin.html">Managing HAWQ Using Ambari</a>
           </li>
           <li>


### PR DESCRIPTION
created a new page called "Introducing the HAWQ Operating Environment".  this new page is located after  "Overview" in the "Running a HAWQ Cluster" subnav.