### PR TITLE
HAWQ-1293 - identify/tag deprecated gucs

### DIFF
--- a/markdown/query/query-profiling.html.md.erb
+++ b/markdown/query/query-profiling.html.md.erb
@@ -88,8 +88,7 @@ The estimated startup cost for this plan is `00.00` (no cost) and a total cost o
     Work_mem wanted: 90K bytes avg, 90K byes max (seg0) to lessen
     workfile I/O affecting 2 workers.
     ```
-**Note**
-The *work\_mem* property is not configurable. Use resource queues to manage memory use. For more information on resource queues, see [Configuring Resource Management](../resourcemgmt/ConfigureResourceManagement.html) and [Working with Hierarchical Resource Queues](../resourcemgmt/ResourceQueues.html).
+**Warning**: The `work_mem` server configuration parameter is deprecated and will be removed in a future HAWQ release. Use resource queues to manage memory use. For more information on resource queues, see [Configuring Resource Management](../resourcemgmt/ConfigureResourceManagement.html) and [Working with Hierarchical Resource Queues](../resourcemgmt/ResourceQueues.html).
 
 -   The time (in milliseconds) in which the segment that produced the most rows retrieved the first row, and the time taken for that segment to retrieve all rows. The result may omit *&lt;time&gt; to first row* if it is the same as the *&lt;time&gt; to end*.
 
@@ -143,7 +142,7 @@ If a query performs poorly, examine its query plan and ask the following questio
 
     `Work_mem used: 23430K bytes avg, 23430K bytes max (seg0). Work_mem               wanted: 33649K bytes avg, 33649K bytes max (seg0) to lessen workfile I/O affecting 2               workers.`
 
-    The "bytes wanted" message from `EXPLAIN               ANALYZE` is based on the amount of data written to work files and is not exact. The minimum `work_mem` needed can differ from the suggested value.
+    The "bytes wanted" message from `EXPLAIN ANALYZE` is based on the amount of data written to work files and is not exact. The minimum `work_mem` needed can differ from the suggested value.
 
 ## <a id="explainplan_plpgsql"></a>Generating EXPLAIN Plan from a PL/pgSQL Function
 

--- a/markdown/reference/guc/parameter_definitions.html.md.erb
+++ b/markdown/reference/guc/parameter_definitions.html.md.erb
@@ -1420,9 +1420,11 @@ Sets the amount of data per-peer to be queued by the UDP interconnect on receive
 
 ## <a name="gp_interconnect_setup_timeout"></a>gp\_interconnect\_setup\_timeout
 
-When the interconnect type is UDP, the time to wait for the Interconnect to complete setup before it times out.
+When the interconnect type is UDP, the time to wait for the Interconnect to complete setup before it times out. 
 
 This parameter is used only when [gp\_interconnect\_type](#gp_interconnect_type) is set to UDP.
+
+**Warning**: The `gp_interconnect_setup_timeout` server configuration parameter is deprecated and will be removed in a future HAWQ release.
 
 | Value Range                                 | Default | Set Classifications     |
 |---------------------------------------------|---------|-------------------------|


### PR DESCRIPTION
identifying the documented deprecated gucs as such.  these include work_mem and gp_interconnect_setup_timeout.