### PR TITLE
Document extending KDC ticket interval

### DIFF
--- a/markdown/clientaccess/kerberos.html.md.erb
+++ b/markdown/clientaccess/kerberos.html.md.erb
@@ -529,7 +529,7 @@ The lifetime of the Kerberos ticket may need to be changed. The ticket lifetime 
 
 **Note:** The kdc.conf file supplements krb5.conf for programs using KDC. The kdc.conf file contains defaults used when issuing Kerberos tickets, as well as KDC configuration information. 
 
-On starting HAWQ, the Resource Manager initializes the  kerberos ticket to expire after 12 hours. On KDC servers, this interval can be even longer. Reset the `server_ticket_renew_interval`  to renew prior to the 12 hour default.
+On starting HAWQ, the Resource Manager initializes the  kerberos ticket to expire after 12 hours. On KDC servers, this interval can be even longer. (Your specific configuration may differ from these standards, so set the ticket to renew before your system ticket lifetime.) Reset the `server_ticket_renew_interval`  to renew prior to the default value and restart the cluster to have the new value take effect.
 
 You will perform different procedures if you use Ambari for cluster management or manage your cluster from the command line.
 
@@ -539,7 +539,7 @@ You will perform different procedures if you use Ambari for cluster management o
 
        2. Navigate to the **HAWQ** service, **Configs > Advanced** tab and expand the **Custom hawq-site** drop down.
 
-       3. Set the value of  `server_ticket_renew_interval` to 18000000. This will renew the ticket every five hours.
+       3. Set the value of  `server_ticket_renew_interval` to renew prior to the default interval. For example set `server_ticket_renew_interval` to 18000000. This will renew the ticket every five hours.
 
        4. **Save** this configuration change and then select the now orange **Restart > Restart All Affected** menu button to restart your HAWQ cluster.
 
@@ -549,17 +549,17 @@ You will perform different procedures if you use Ambari for cluster management o
 
       1.  On all KDC servers, open the KDC configuration file `/etc/krb5kdc/kdc.conf` and change `max_life` to a value less than the renewal interval.
 
-      2. Use `hawq config` to change `server_ticket_renew_interval` to 18000000 to renew the ticket every five hours. (Or edit kdc.conf or krb5.conf to add `server_ticket_renew_interval = 18000000`?
+      2. Use `hawq config` to change `server_ticket_renew_interval` to 18000000 to renew the ticket every five hours. The following example shows setting it to 18000000.
 
         ``` shell
         gpadmin@kdc_server$ hawq config -v server_ticket_renew_interval = 18000000 
         ``` 
         
-      3. Restart the HAWQ cluster:
+Restart the HAWQ cluster:
 
-        ``` shell
-        gpadmin@master$ hawq restart cluster 
-        ``` 
+``` shell
+gpadmin@master$ hawq restart cluster 
+``` 
       
 Note that when a client asks the KDC for a session ticket to a service, it can request a specific start time. If the start time is missing or already past, the KDC sets the ticket's `starttime` field to the current time. The KDC determines the end time by adding the maximum ticket life to the `starttime` value. 
 

--- a/markdown/clientaccess/kerberos.html.md.erb
+++ b/markdown/clientaccess/kerberos.html.md.erb
@@ -476,7 +476,8 @@ Perform the following steps to configure Kerberos authentication for specific HA
 
 ### <a id="hawq_kerb_dbaccess"></a>Authenticating User Access to HAWQ 
 
-When Kerberos user authentication is enabled for HAWQ, users must request a ticket from the Kerberos KDC server before connecting to HAWQ. You must request the ticket for a principal matching the requested database user name. When granted, the ticket expires after a set period of time, after which you will need to request another ticket.
+When Kerberos user authentication is enabled for HAWQ, users must request a ticket from the Kerberos KDC server before connecting to HAWQ. You must request the ticket for a principal matching the requested database user name. When granted, the ticket expires after a set period of time, after which you must either request another ticket or have the ticket renewed. The default expiration time is 12 hours, set in the parameter `server_ticket_renew_interval`. To avoid KDC access issues, the ticket should be renewed before it expires.
+See 
    
 To generate a Kerberos ticket, run the `kinit` command. Specify the Kerberos principal for which you are requesting the ticket in a command option. You may optionally specify a path to a keytab file.
 
@@ -514,6 +515,47 @@ Valid starting     Expires            Service principal
 ```
 
 After generating a ticket, you can connect to a HAWQ database as a kerberos-authenticated user using `psql` or other client programs.
+
+### <a id="change_ticket"></a>Changing the Ticket Renewal Interval
+
+The lifetime of the Kerberos ticket may need to be changed. The ticket lifetime is the minimum of the following values:
+
+* `max_life` in `kdc.conf` on the KDC servers.
+* `ticket_lifetime` in `krb5.conf` on the client
+* maxlife for the user principal
+* maxlife for the service principal in krbtgt\[REALM\]
+* maxlife for the AFS service principal "afs/[realm_in_lower_case]"
+* the requested lifetime in the ticket request
+
+**Note:** The kdc.conf file supplements krb5.conf for programs using KDC. The kdc.conf file contains defaults used when issuing Kerberos tickets, as well as KDC configuration information. 
+
+On starting HAWQ, the Resource Manager initializes the  kerberos ticket to expire after 12 hours. On KDC servers, this interval can be even longer. Reset the `server_ticket_renew_interval`  to renew prior to the 12 hour default.
+
+You will perform different procedures if you use Ambari for cluster management or manage your cluster from the command line.
+
+  1. If you manage your cluster using Ambari:
+    
+       1.  Login to the Ambari UI from a supported web browser.
+
+        2. Navigate to the **HAWQ** service, **Configs > Advanced** tab and expand the **Custom hawq-site** drop down.
+
+        3. Set the value of  `server_ticket_renew_interval` to 18000000. This will renew the ticket every five hours.
+
+        4. **Save** this configuration change and then select the now orange **Restart > Restart All Affected** menu button to restart your HAWQ cluster.
+
+        5. Exit the Ambari UI.  
+    
+    2. If you manage your cluster from the command line:
+      1.  On all KDC servers, open the KDC configuration file `/etc/krb5kdc/kdc.conf` and change `max_life` to a value less than the renewal interval.
+
+      2. Use `hawq config` to change `server_ticket_renew_interval` to 18000000 to renew the ticket every five hours. (Or edit kdc.conf or krb5.conf to add `server_ticket_renew_interval = 18000000`?
+      3. Restart the HAWQ cluster:
+
+        ``` shell
+        gpadmin@master$ hawq restart cluster 
+        ``` 
+      
+Note that when a client asks the KDC for a session ticket to a service, it can request a specific start time. If the start time is missing or already past, the KDC sets the ticket's `starttime` field to the current time. The KDC determines the end time by adding the maximum ticket life to the `starttime` value. 
 
 #### <a id="topic7"></a>Name Mapping 
 
@@ -622,7 +664,7 @@ Follow these steps to install and configure a Kerberos KDC server on a Red Hat E
     root@kdc-server$ yum install krb5-libs krb5-server krb5-workstation
     ```
 
-3.  Define the Kerberos realm for your cluster by editting the `/etc/krb5.conf` configuration file. The following example configures a Kerberos server with a realm named `REALM.DOMAIN` residing on a host named `hawq-kdc`.
+3.  Define the Kerberos realm for your cluster by editing the `/etc/krb5.conf` configuration file. The following example configures a Kerberos server with a realm named `REALM.DOMAIN` residing on a host named `hawq-kdc`.
 
     ```
     [logging]
@@ -664,7 +706,7 @@ Follow these steps to install and configure a Kerberos KDC server on a Red Hat E
 
     The `kdc` and `admin_server` keys in the `[realms]` section specify the host \(`hawq-kdc`\) and port on which the Kerberos server is running. You can use an IP address in place of a host name.
 
-    If your Kerberos server manages authentication for other realms, you would instead add the `REALM.DOMAINM` realm in the `[realms]` and `[domain_realm]` sections of the `krb5.conf` file. See the [Kerberos documentation](http://web.mit.edu/kerberos/krb5-latest/doc/) for detailed information about the `krb5.conf` configuration file.
+    If your Kerberos server manages authentication for other realms, you would instead add the `REALM.DOMAIN` realm in the `[realms]` and `[domain_realm]` sections of the `krb5.conf` file. See the [Kerberos documentation](http://web.mit.edu/kerberos/krb5-latest/doc/) for detailed information about the `krb5.conf` configuration file.
 
 4. Note the Kerberos KDC server host name or IP address and the name of the realm in which your cluster resides. You will need this information in later procedures.
 5.  Create a Kerberos KDC database by running the `kdb5_util` command:

--- a/markdown/clientaccess/kerberos.html.md.erb
+++ b/markdown/clientaccess/kerberos.html.md.erb
@@ -476,8 +476,9 @@ Perform the following steps to configure Kerberos authentication for specific HA
 
 ### <a id="hawq_kerb_dbaccess"></a>Authenticating User Access to HAWQ 
 
-When Kerberos user authentication is enabled for HAWQ, users must request a ticket from the Kerberos KDC server before connecting to HAWQ. You must request the ticket for a principal matching the requested database user name. When granted, the ticket expires after a set period of time, after which you must either request another ticket or have the ticket renewed. The default expiration time is 12 hours, set in the parameter `server_ticket_renew_interval`. To avoid KDC access issues, the ticket should be renewed before it expires.
-See 
+When Kerberos user authentication is enabled for HAWQ, users must request a ticket from the Kerberos KDC server before connecting to HAWQ. You must request the ticket for a principal matching the requested database user name. When granted, the ticket expires after a set period of time, after which you must either request another ticket or have the ticket renewed. The default expiration time on HAWQ is 12 hours, set in the parameter `server_ticket_renew_interval`. To avoid KDC access issues, the ticket should be renewed before it expires.
+
+**Note** The actual ticket expiration interval depends on the Kerberos software configuration, and may differ from the HAWQ setting. For more information, see [Changing the Ticket Renewal Interval](#change_ticket).
    
 To generate a Kerberos ticket, run the `kinit` command. Specify the Kerberos principal for which you are requesting the ticket in a command option. You may optionally specify a path to a keytab file.
 
@@ -490,7 +491,7 @@ bill@hawq-node$ kinit -k -t /home/bill/bill-krb5.keytab bill_kerberos@REALM.DOMA
 To request a ticket for the `bill_kerberos` user principal using password authentication:
 
 ``` shell
-bill@hawq-node$ kinit bill_kerberos@REALM.DOMAIN
+bill@hawq-node$ kinit -k bill_kerberos@REALM.DOMAIN
 Password for bill_kerberos@REALM.DOMAIN:
 ```
 
@@ -527,7 +528,7 @@ The lifetime of the Kerberos ticket may need to be changed. The ticket lifetime 
 * maxlife for the AFS service principal "afs/[realm_in_lower_case]"
 * the requested lifetime in the ticket request
 
-**Note:** The kdc.conf file supplements krb5.conf for programs using KDC. The kdc.conf file contains defaults used when issuing Kerberos tickets, as well as KDC configuration information. 
+**Note:** The kdc.conf file supplements krb5.conf for programs using KDC. The kdc.conf file contains defaults used when issuing Kerberos tickets, such as the HAWQ `server_ticket_renewal_interval` value, as well as KDC configuration information. 
 
 On starting HAWQ, the Resource Manager initializes the  kerberos ticket to expire after 12 hours. On KDC servers, this interval can be even longer. (Your specific configuration may differ from these standards, so set the ticket to renew before your system ticket lifetime.) Reset the `server_ticket_renew_interval`  to renew prior to the default value and restart the cluster to have the new value take effect.
 
@@ -539,7 +540,7 @@ You will perform different procedures if you use Ambari for cluster management o
 
        2. Navigate to the **HAWQ** service, **Configs > Advanced** tab and expand the **Custom hawq-site** drop down.
 
-       3. Set the value of  `server_ticket_renew_interval` to renew prior to the default interval. For example set `server_ticket_renew_interval` to 18000000. This will renew the ticket every five hours.
+       3. Set the value (in milliseconds) of  `server_ticket_renew_interval` to renew prior to the default interval. For example set `server_ticket_renew_interval` to 18000000. This will renew the ticket every five hours.
 
        4. **Save** this configuration change and then select the now orange **Restart > Restart All Affected** menu button to restart your HAWQ cluster.
 
@@ -547,9 +548,9 @@ You will perform different procedures if you use Ambari for cluster management o
     
    2. If you manage your cluster from the command line:
 
-      1.  On all KDC servers, open the KDC configuration file `/etc/krb5kdc/kdc.conf` and change `max_life` to a value less than the renewal interval.
+      1.  On all KDC servers, open the KDC configuration file `/etc/krb5kdc/kdc.conf` and change `max_life` to a value (in milliseconds) less than the renewal interval.
 
-      2. Use `hawq config` to change `server_ticket_renew_interval` to 18000000 to renew the ticket every five hours. The following example shows setting it to 18000000.
+      2. Use `hawq config` to change the value (in milliseconds) of `server_ticket_renew_interval` to 18000000 to renew the ticket every five hours. The following example shows setting it to 18000000.
 
         ``` shell
         gpadmin@kdc_server$ hawq config -v server_ticket_renew_interval = 18000000 
@@ -717,7 +718,14 @@ Follow these steps to install and configure a Kerberos KDC server on a Red Hat E
 4. Note the Kerberos KDC server host name or IP address and the name of the realm in which your cluster resides. You will need this information in later procedures.
 5.  Create a Kerberos KDC database by running the `kdb5_util` command:
 
-    ```
+### <a id="task_setup_kdc_linux"></a>Install and Configure KDC Server on Linux
+
+Follow these steps to install and configure a Kerberos KDC server on a Red Hat Enterprise Linux host. The KDC server resides on the host named \<kdc-server\>.
+
+1. Log in to the Kerberos KDC Server system as a superuser:
+
+    ``` shell
+    $ ssh root@<kdc-server>
     root@kdc-server$ kdb5_util create -s
     ```
 
@@ -745,3 +753,172 @@ Follow these steps to install and configure a Kerberos KDC server on a Red Hat E
     root@kdc-server$ /sbin/chkconfig krb5kdc on
     root@kdc-server$ /sbin/chkconfig kadmin on
     ```
+    
+### <a id="task_setup_kdc_ad"></a>Install and Configure KDC Server on Active Directory
+
+Follow these steps to install and configure a Kerberos KDC server on a Windows host with Active Directory. 
+
+1. Log into the Windows server as a user with administrator permissions. 
+
+2. From the **Start** menu, select **Control Panel** \> **Adminisrative Tools** \> **Active Directory Users and Computers**. 
+
+   Note: If there is no entry for **Active Directory Users and Computers**, Active Directory service may not have been correctly installed. 
+
+3. Go to the DATALOCAL entry in the directory tree of the **Active Directory Users and Computers** window and  right click on **Managed Service Accounts**. 
+
+4.  Select **New** \> **User**.
+
+5.  A **New Object - User** popup window will appear. In the **First name:** window, enter `gpadmin` and also enter `gpadnub` as the **User logon name**.
+
+6. Click **Next**. Create and confirm a password. Enable the checkbox for **Password never expires**. Click **Next**, then **Finish**. 
+
+7. Log into Windows as Administrator. Depending on your Windows environment, either open a Windows power shell or click **Start** and open a command prompt session and select **Run as Administrator** \> **Yes** to open an administrator window.
+
+8. Add a Service Principal Name (SPN) for the account just created:
+
+   ``` shell
+   PS C:\Users\Administrator> setspn -A postgres/hdp3.example.com gpadmin
+   ```
+   
+9. Generate a keytab file by using the `ktpass` command. This command takes the form:
+
+   ``` shell
+   ktpass -princ postgres/<FQDN of HDB master> -pass <password> -mapuser <Managed Service Account name> -crypto ALL -ptype KRB5_NT_PRINCIPAL -out <keytab filename> -kvno 0 
+   ```
+   For example, to create `hdp3.keytab` for gpadmin on hdp3.mydomain.com@DATA.LOCAL:
+   
+   ``` shell
+   PS C:\Users\Administrator> ktpass -princ postgres/hdp3.mydomain.com@DATA.LOCAL -pass abcd1234 -mapuser gpadmin -crypto ALL -ptype KRB5_NT_PRINCIPAL -out hdp3.keytab -kvno 0
+   
+   Targeting domain controller: WIN-TIH2EBEERUK.DATA.LOCAL
+   
+   Using legacy password setting method
+   Key created.
+   Key created.
+   Key created.
+   Key created.
+   Key created.
+   Output keytab to hdp3.keytab:
+   Keytab version: 0x502
+   keysize 61 postgres/hdp3.example.com@DATA.LOCAL ptype 1 (KRB5_NT_PRINCIPAL) vno 0 etype 0x1 (DES-CBC-CRC) keylength 8 (0xa8d0405789a8469e)
+keysize 61 postgres/hdp3.example.com@DATA.LOCAL ptype 1 (KRB5_NT_PRINCIPAL) vno 0 etype 0x3 (DES-CBC-MD5) keylength 8 (0xa8d0405789a8469e)
+keysize 69 postgres/hdp3.example.com@DATA.LOCAL ptype 1 (KRB5_NT_PRINCIPAL) vno 0 etype 0x17 (RC4-HMAC) keylength 16 (0x161cff084477fe596a5db81874498a24)
+keysize 85 postgres/hdp3.example.com@DATA.LOCAL ptype 1 (KRB5_NT_PRINCIPAL) vno 0 etype 0x12 (AES256-SHA1) keylength 32 (0x20648bd82de77bf66a1dcac4b3050bc308f2cc38f4a13e814ad5bd30e67ef388)
+keysize 69 postgres/hdp3.example.com@DATA.LOCAL ptype 1 (KRB5_NT_PRINCIPAL) vno 0 etype 0x11 (AES128-SHA1) keylength 16 (0xa026bb25aa495af5334cd4f185d33071):
+   ```
+   
+10. Transfer the generated keytab file to the HDB master. For example:
+
+    ``` shell
+    root@kdc-server$ scp /etc/ad_keytab/keytabs/hawq.service.keytab <master>:/etc/ad_keytab/keytabs/hawq.service.keytab
+    ```
+Change the ownership of the keytab file to `gpadmin:gpadmin` and the mode to `600`. 
+
+
+    ``` shell
+    root@kdc-server$ ssh <master> chown gpadmin:gpadmin /etc/ad_keytab/keytabs/hawq.service.keytab
+    root@kdc-server$ ssh <master> chmod 600 /etc/ad_keytab/keytabs/hawq.service.keytab
+    ```
+    
+***Can you use automated kerberos setup on Ambari?**
+
+11. Log into HAWQ through the administrator window and install the Kerberos packages on the HAWQ master. 
+
+12. Change the ticket renewal interval.
+
+13. Edit the `.etc/krb5.conf` configuration file to define the Kerberos realm for the cluster. 
+
+   **Can you set up with PS C:\Users\Administrator> ? What if you use Ambari? This page has commands for Powershell: 
+   https://hortonworks.com/blog/enabling-kerberos-hdp-active-directory-integration/**
+
+   The following example shows configuring the Kerberos server for the default DATA.LOCAL realm on the KDC host `my-kdc`.
+   
+   ``` shell
+   [logging]
+ default = FILE:/var/log/krb5libs.log
+ kdc = FILE:/var/log/krb5kdc.log
+ admin_server = FILE:/var/log/kadmind.log
+[libdefaults]
+ default_realm = DATA.LOCAL
+ default_tkt_enctypes = rc4-hmac des-cbc-crc des-cbc-md5
+ default_tgs_enctypes = rc4-hmac des-cbc-crc des-cbc-md5
+ dns_lookup_realm = false
+ dns_lookup_kdc = false
+ ticket_lifetime = 24h
+ renew_lifetime = 7d
+ forwardable = true
+[realms]
+ DATA.LOCAL = {
+ kdc = my-kdc:88
+ admin_server = my-kdc:749
+ }
+[domain_realm]
+my-kdc = DATA.LOCAL
+ .my-kdc = DATA.LOCAL
+ .data.local = DATA.LOCAL
+ data.local = DATA.LOCAL
+
+   ```
+The kdc and admin_server keys in the [realms] section specify the host `my-kdc` and port where the Kerberos server is running. You can use an IP address in place of a host name. If your Kerberos server manages authentication for other realms, you would instead add the \<REALM.DOMAIN\> in the `[realms]` and `[domain_realm]` sections of the `krb5.conf` file. See the [Kerberos documentation](http://web.mit.edu/kerberos/krb5-latest/doc/) for detailed information about the `krb5.conf` configuration file.
+
+14. Specify the location of the keytab file.
+
+  Note: If you use Ambari to manage your cluster, perform all steps through Ambari. If setup is done through the command line on an Ambari Cluster, Ambari will overwrite the settings on startup.  
+  
+ **Using Ambari for keytab configuration:**
+  
+ If you use Ambari for managing your HAWQ cluster:
+     
+   1. Login in to the Ambari UI from a supported web browser.
+   2. Navigate to the **HAWQ** service, **Configs > Advanced** tab and expand the **Custom hawq-site** drop down.
+   3. Set the `krb_server_keyfile` path value to the new keytab file location, `/home/gpadmin/hawq-krb5.keytab`.
+   4. **Save** this configuration change and then select the now orange **Restart > Restart All Affected** menu button to restart your HAWQ cluster.    **Correct process?? Hortonworks has something about running scripts. See https://hortonworks.com/blog/enabling-kerberos-hdp-active-directory-integration/**
+
+
+**Using the Command Line for Keytab Configuration**
+
+1. Use `hawq config` to update hawq-site.xml to specify the location of the keytab file. The example below shows adding the folder /home/gpadmin as the location of the keytab file `hdp3.keytab`. 
+
+   ``` shell
+   gpadmin@master$ hawq config -c krb_server_keyfile -v '/home/gpadmin/hdb3.keytab'
+   GUC krb_server_keyfile already exist in hawq-site.xml
+   Update it with value: /home/gpadmin/hawq-krb5.keytab
+   GUC      : krb_server_keyfile
+   Value    : /home/gpadmin/hawq-krb5.keytab
+   ```
+
+  Modify the HDB file `pg_hba.conf `to enable Kerberos support. This `pg_hba.conf` entry specifies that any remote access (i.e. from any user on any remote host) to HAWQ must be authenticated through the Kerberos realm named `DATA.LOCAL`. 
+
+  For example, adding the line shown below to `pg_hba.conf` adds GSSAPI and Kerberos support. The value for `krb_realm` is the Kerberos realm that is used for HDB authentication.
+  
+   ``` shell
+host all all 0.0.0.0/0 gss include_realm=0 krb_realm=DATA.LOCAL
+   ```
+    **Note**: You must place the Kerberos entry in the appropriate location in the `pg_hba.conf` file. For example, you may choose to retain `pg_hba.conf` entries for the `gpadmin` user that grant `trust` or `ident` authentication for local connections. Locate the Kerberos entry after these line(s). Refer to [Configuring Client Authentication](client_auth.html) for additional information about the `pg_hba.conf` file.
+    
+2. When finished modifying `pg_hba.conf`, restart your HAWQ cluster by entering: 
+
+   ``` shell
+   hawq restart cluster -a
+   ```
+
+3. Use `kinit` to create an HDFS Kerberos ticket. Show the tickets in the Kerberos ticket cache by running `klist`. 
+
+   ``` shell
+[gpadmin@hdp3 ~]$ kinit gpadmin
+Password for gpadmin@DATA.LOCAL: 
+[gpadmin@hdp3 ~]$ klist
+Ticket cache: FILE:/tmp/krb5cc_1002
+Default principal: gpadmin@DATA.LOCAL
+Valid starting Expires Service principal
+06/08/17 09:24:19 06/08/17 19:24:33 krbtgt/DATA.LOCAL@DATA.LOCAL
+ renew until 06/15/17 09:24:19
+   ```
+   
+   Note: If you receive the error "Preauthentication failed while getting initial credentials" open the **Account** tab on the Active Directory server and select the box for **Do not require Kerberos preauthentication** from the **Account** options.
+
+4. Test the Kerberos connection by logging into the database as gpadmin, with the gpadmin Kerberos credentials. 
+```
+$ psql -U gpadmin -h hdp3.example.com template1
+```
+

--- a/markdown/clientaccess/kerberos.html.md.erb
+++ b/markdown/clientaccess/kerberos.html.md.erb
@@ -525,12 +525,12 @@ The lifetime of the Kerberos ticket may need to be changed. The ticket lifetime 
 * `ticket_lifetime` in `krb5.conf` on the client
 * maxlife for the user principal
 * maxlife for the service principal in krbtgt\[REALM\]
-* maxlife for the AFS service principal "afs/[realm_in_lower_case]"
+* maxlife for the AFS service principal afs\[realm\_in\_lower\_case\]
 * the requested lifetime in the ticket request
 
 **Note:** The kdc.conf file supplements krb5.conf for programs using KDC. The kdc.conf file contains defaults used when issuing Kerberos tickets, such as the HAWQ `server_ticket_renewal_interval` value, as well as KDC configuration information. 
 
-On starting HAWQ, the Resource Manager initializes the  kerberos ticket to expire after 12 hours. On KDC servers, this interval can be even longer. (Your specific configuration may differ from these standards, so set the ticket to renew before your system ticket lifetime.) Reset the `server_ticket_renew_interval`  to renew prior to the default value and restart the cluster to have the new value take effect.
+On starting HAWQ, the Resource Manager initializes the  kerberos ticket to expire after 12 hours. On KDC servers, this interval can be even longer. (Your specific configuration may differ from these standards, so set the ticket to renew before your own system ticket lifetime.) Reset the `server_ticket_renew_interval`  to renew prior to the default interval value and restart the cluster to have the new value take effect.
 
 You will perform different procedures if you use Ambari for cluster management or manage your cluster from the command line.
 
@@ -546,21 +546,19 @@ You will perform different procedures if you use Ambari for cluster management o
 
        5. Exit the Ambari UI.  
     
-   2. If you manage your cluster from the command line:
+  2. If you manage your cluster from the command line:
 
-      1.  On all KDC servers, open the KDC configuration file `/etc/krb5kdc/kdc.conf` and change `max_life` to a value (in milliseconds) less than the renewal interval.
-
-      2. Use `hawq config` to change the value (in milliseconds) of `server_ticket_renew_interval` to 18000000 to renew the ticket every five hours. The following example shows setting it to 18000000.
+      Use `hawq config` to change the value (in milliseconds) of `server_ticket_renew_interval` to to renew the ticket before its default expiration value. The following example shows setting it to 18000000 (every 5 hours).
 
         ``` shell
         gpadmin@kdc_server$ hawq config -v server_ticket_renew_interval = 18000000 
         ``` 
         
-Restart the HAWQ cluster:
+  Restart the HAWQ cluster:
 
-``` shell
-gpadmin@master$ hawq restart cluster 
-``` 
+  ``` shell
+  gpadmin@master$ hawq restart cluster 
+  ``` 
       
 Note that when a client asks the KDC for a session ticket to a service, it can request a specific start time. If the start time is missing or already past, the KDC sets the ticket's `starttime` field to the current time. The KDC determines the end time by adding the maximum ticket life to the `starttime` value. 
 
@@ -827,9 +825,6 @@ Change the ownership of the keytab file to `gpadmin:gpadmin` and the mode to `60
 12. Change the ticket renewal interval.
 
 13. Edit the `.etc/krb5.conf` configuration file to define the Kerberos realm for the cluster. 
-
-   **Can you set up with PS C:\Users\Administrator> ? What if you use Ambari? This page has commands for Powershell: 
-   https://hortonworks.com/blog/enabling-kerberos-hdp-active-directory-integration/**
 
    The following example shows configuring the Kerberos server for the default DATA.LOCAL realm on the KDC host `my-kdc`.
    

--- a/markdown/clientaccess/kerberos.html.md.erb
+++ b/markdown/clientaccess/kerberos.html.md.erb
@@ -537,18 +537,24 @@ You will perform different procedures if you use Ambari for cluster management o
     
        1.  Login to the Ambari UI from a supported web browser.
 
-        2. Navigate to the **HAWQ** service, **Configs > Advanced** tab and expand the **Custom hawq-site** drop down.
+       2. Navigate to the **HAWQ** service, **Configs > Advanced** tab and expand the **Custom hawq-site** drop down.
 
-        3. Set the value of  `server_ticket_renew_interval` to 18000000. This will renew the ticket every five hours.
+       3. Set the value of  `server_ticket_renew_interval` to 18000000. This will renew the ticket every five hours.
 
-        4. **Save** this configuration change and then select the now orange **Restart > Restart All Affected** menu button to restart your HAWQ cluster.
+       4. **Save** this configuration change and then select the now orange **Restart > Restart All Affected** menu button to restart your HAWQ cluster.
 
-        5. Exit the Ambari UI.  
+       5. Exit the Ambari UI.  
     
-    2. If you manage your cluster from the command line:
+   2. If you manage your cluster from the command line:
+
       1.  On all KDC servers, open the KDC configuration file `/etc/krb5kdc/kdc.conf` and change `max_life` to a value less than the renewal interval.
 
       2. Use `hawq config` to change `server_ticket_renew_interval` to 18000000 to renew the ticket every five hours. (Or edit kdc.conf or krb5.conf to add `server_ticket_renew_interval = 18000000`?
+
+        ``` shell
+        gpadmin@kdc_server$ hawq config -v server_ticket_renew_interval = 18000000 
+        ``` 
+        
       3. Restart the HAWQ cluster:
 
         ``` shell

--- a/markdown/reference/guc/parameter_definitions.html.md.erb
+++ b/markdown/reference/guc/parameter_definitions.html.md.erb
@@ -478,6 +478,8 @@ Descriptions of the HAWQ server configuration parameters listed alphabetically.
 
 -   **[server\_encoding](../../reference/guc/parameter_definitions.html#server_encoding)**
 
+-   **[server\_encoding](../../reference/guc/parameter_definitions.html#server_ticket_renew_interval)**
+
 -   **[server\_version](../../reference/guc/parameter_definitions.html#server_version)**
 
 -   **[server\_version\_num](../../reference/guc/parameter_definitions.html#server_version_num)**
@@ -3006,6 +3008,14 @@ Reports the database encoding (character set). It is determined when the HAWQ ar
 | Value Range              | Default | Set Classifications |
 |--------------------------|---------|---------------------|
 | &lt;system dependent&gt; | UTF8    | read only           |
+
+## <a name="server_ticket_renew_interval"></a>server\__ticket\_renew\_interval
+
+Sets the Kerberos ticket renew interval in milliseconds.
+
+| Value Range              | Default | Set Classifications |
+|--------------------------|---------|---------------------|
+| integer | 43200000    |master, system, restart           |
 
 ## <a name="server_version"></a>server\_version
 

--- a/markdown/resourcemgmt/YARNIntegration.html.md.erb
+++ b/markdown/resourcemgmt/YARNIntegration.html.md.erb
@@ -254,6 +254,8 @@ If you have enabled high-availability for your YARN resource managers, then spec
 
 where {0} and {1} are substituted with the fully qualified hostnames of the YARN resource manager host machines.
 
+To reduce the time needed to locate the resource manager, the master resource manager for YARN should be first in this list, followed by the standby resource manager.
+
 ## <a id="topic_wp3_4bx_15"></a>Tune HAWQ Resource Negotiations with YARN 
 
 To ensure efficient management of resources and highest performance, you can configure some aspects of how HAWQ's resource manager negotiate resources from YARN.


### PR DESCRIPTION
Extending the ticket interval is needed for Kerberos Active Directory support. Also added back guc that was previously documented in PHD