### PR TITLE
server_ticket_renew_interval guc, YARN HA props

### DIFF
--- a/book/master_middleman/source/subnavs/apache-hawq-nav.erb
+++ b/book/master_middleman/source/subnavs/apache-hawq-nav.erb
@@ -800,6 +800,7 @@
                   <li><a href="/docs/userguide/2.2.0.0-incubating/reference/guc/parameter_definitions.html#seg_max_connections">seg_max_connections</a></li>
                   <li><a href="/docs/userguide/2.2.0.0-incubating/reference/guc/parameter_definitions.html#seq_page_cost">seq_page_cost</a></li>
                   <li><a href="/docs/userguide/2.2.0.0-incubating/reference/guc/parameter_definitions.html#server_encoding">server_encoding</a></li>
+                  <li><a href="/docs/userguide/2.2.0.0-incubating/reference/guc/parameter_definitions.html#server_ticket_renew_interval">server_ticket_renew_interval</a></li>
                   <li><a href="/docs/userguide/2.2.0.0-incubating/reference/guc/parameter_definitions.html#server_version">server_version</a></li>
                   <li><a href="/docs/userguide/2.2.0.0-incubating/reference/guc/parameter_definitions.html#server_version_num">server_version_num</a></li>
                   <li><a href="/docs/userguide/2.2.0.0-incubating/reference/guc/parameter_definitions.html#shared_buffers">shared_buffers</a></li>

--- a/markdown/clientaccess/kerberos-securehdfs.html.md.erb
+++ b/markdown/clientaccess/kerberos-securehdfs.html.md.erb
@@ -217,3 +217,39 @@ Perform the following steps to configure HAWQ and PXF for a secure HDFS. You wil
         ``` shell
         gpadmin@master$ hawq restart cluster -a -M fast
         ```
+
+## <a id="server_ticket_renew"></a>Setting the HAWQ Kerberos Ticket Renewal Interval
+
+The HAWQ [`server_ticket_renew_interval`](../reference/guc/parameter_definitions.html#server_ticket_renew_interval) server configuration parameter governs the HAWQ HDFS client Kerberos ticket renewal interval. The default ticket renewal interval is 12 hours.
+
+You configure the lifetime of a Kerberos ticket when you set up your KDC. To avoid ticket expiration, set the `server_ticket_renew_interval` to a value that is less than the lifetime of the ticket. 
+
+#### <a id="task_kerbhdfs_ticket_renew"></a>Procedure
+
+You will perform different procedures to set the ticket renewal interval if you manage your cluster from the command line or use Ambari to manage your cluster.
+
+1. If you manage your cluster using Ambari:
+    
+    1.  Login in to the Ambari UI from a supported web browser.
+
+    2. Navigate to the **HAWQ** service, **Configs > Advanced** tab and expand the **Custom hawq-site** drop down.
+
+    3. Set the `server_ticket_renew_interval` value to the desired ticket renewal interval in milliseconds.
+
+    4. **Save** this configuration change and then select the now orange **Restart > Restart All Affected** menu button to restart your HAWQ cluster.
+
+    5. Exit the Ambari UI.  
+    
+2. If you manage your cluster from the command line:
+    
+    1.  Use the `hawq config` command to update the `server_ticket_renew_interval` configuration parameter. For example:
+
+        ``` shell
+        gpadmin@master$ hawq config -c server_ticket_renew_interval -v 86400000
+        ```
+
+    2.  Restart your HAWQ cluster:
+
+        ``` shell
+        gpadmin@master$ hawq restart cluster
+        ```

--- a/markdown/reference/guc/parameter_definitions.html.md.erb
+++ b/markdown/reference/guc/parameter_definitions.html.md.erb
@@ -478,6 +478,8 @@ Descriptions of the HAWQ server configuration parameters listed alphabetically.
 
 -   **[server\_encoding](../../reference/guc/parameter_definitions.html#server_encoding)**
 
+-   **[server\_ticket\_renew\_interval](../../reference/guc/parameter_definitions.html#server_ticket_renew_interval)**
+
 -   **[server\_version](../../reference/guc/parameter_definitions.html#server_version)**
 
 -   **[server\_version\_num](../../reference/guc/parameter_definitions.html#server_version_num)**
@@ -1805,7 +1807,7 @@ Adds a checksum value to each block of a work file (or spill file) used by `Hash
 
 ## <a name="gp_workfile_compress_algorithm"></a>gp\_workfile\_compress\_algorithm
 
-When a hash aggregation or hash join operation spills to disk during query processing, specifies the compression algorithm to use on the spill files. 
+When a hash aggregation or hash join operation spills to disk during query processing, specifies the compression algorithm to use on the spill files.
 
 If your HAWQ database installation uses serial ATA (SATA) disk drives, setting the value of this parameter to `zlib` might help to avoid overloading the disk subsystem with IO operations.
 
@@ -3006,6 +3008,16 @@ Reports the database encoding (character set). It is determined when the HAWQ ar
 | Value Range              | Default | Set Classifications |
 |--------------------------|---------|---------------------|
 | &lt;system dependent&gt; | UTF8    | read only           |
+
+
+## <a name="server_ticket_renew_interval"></a>server\_ticket\_renew\_interval
+
+Sets the HAWQ HDFS client Kerberos ticket renewal interval in milliseconds.
+
+| Value Range              | Default | Set Classifications |
+|--------------------------|---------|---------------------|
+| 0-INT\_MAX | 43200000    | master, system, restart       |
+
 
 ## <a name="server_version"></a>server\_version
 

--- a/markdown/resourcemgmt/YARNIntegration.html.md.erb
+++ b/markdown/resourcemgmt/YARNIntegration.html.md.erb
@@ -254,6 +254,8 @@ If you have enabled high-availability for your YARN resource managers, then spec
 
 where {0} and {1} are substituted with the fully qualified hostnames of the YARN resource manager host machines.
 
+To reduce connection time between HAWQ and YARN, be sure to specify the YARN master and standby resource manager hostnames first in the `yarn.resourcemanager.*` property lists.
+
 ## <a id="topic_wp3_4bx_15"></a>Tune HAWQ Resource Negotiations with YARN 
 
 To ensure efficient management of resources and highest performance, you can configure some aspects of how HAWQ's resource manager negotiate resources from YARN.

--- a/markdown/resourcemgmt/YARNIntegration.html.md.erb
+++ b/markdown/resourcemgmt/YARNIntegration.html.md.erb
@@ -254,7 +254,7 @@ If you have enabled high-availability for your YARN resource managers, then spec
 
 where {0} and {1} are substituted with the fully qualified hostnames of the YARN resource manager host machines.
 
-To reduce connection time between HAWQ and YARN, be sure to specify the YARN master and standby resource manager hostnames first in the `yarn.resourcemanager.*` property lists.
+To reduce connection time between HAWQ and YARN, be sure to specify the YARN master hostname first in the `yarn.resourcemanager.*` property lists, and the YARN standby resource manager hostname second in the lists.
 
 ## <a id="topic_wp3_4bx_15"></a>Tune HAWQ Resource Negotiations with YARN 
 


### PR DESCRIPTION
- document server_ticket_renew_interval GUC
- clarify YARN HA property lists

links:
- http://docs-hdb-review.cfapps.io/review/hawq/resourcemgmt/YARNIntegration.html#highlyavailableyarn - added new paragraph to end of the section to identify master and standby first in property lists
- http://docs-hdb-review.cfapps.io/review/hawq/reference/guc/parameter_definitions.html#server_ticket_renew_interval - add new server_ticket_renew_interval GUC to ref guide
- http://docs-hdb-review.cfapps.io/review/hawq/clientaccess/kerberos-securehdfs.html#server_ticket_renew - add section documenting the guc and how to change 